### PR TITLE
Replace deprecated function pcap_lookupdev() with pcap_findalldevs()

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -237,13 +237,20 @@ int main(int argc, char **argv)
    /* If no iface was specified, autoselect one. exit, if no one available */
    if (datos.interface == NULL)
    {
-      datos.interface = pcap_lookupdev(errbuf);
+      pcap_if_t *devices = NULL;
 
-      if (datos.interface == NULL)
-      {
-         printf("Couldn't find default device: %s\n", errbuf);
+      if (pcap_findalldevs(&devices, errbuf) != 0) {
+         printf("Couldn't find capture devices: %s\n", errbuf);
          exit(1);
       }
+
+      if (devices == NULL || devices->name == NULL) {
+         printf("Couldn't find suitable capture device: %s\n", errbuf);
+         exit(1);
+      }
+
+      datos.interface = strdup(devices->name);
+      pcap_freealldevs(devices);
    }
 
    /* Load user config files or set defaults */


### PR DESCRIPTION
`pcap_lookupdev()` was deprecated just over 4 years ago in 2017, but is still present in the latest version of `libpcap`:

https://github.com/the-tcpdump-group/libpcap/commit/7318c9438ce3ac629b2da529d4153fc6aeeb17d4

I'm not sure if you want to merge this so as to continue to support old version of `libpcap`, but presumably the `libpcap` team will remove `pcap_lookupdev()` eventually.

Fixes #10.