### PR TITLE
Fixed segfault when HOME env is not set

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -254,24 +254,41 @@ int main(int argc, char **argv)
       pcap_freealldevs(devices);
    }
 
+   /* Check whether user config files are either disabled or can be found */
+   if ((flag_ignore_files != 1) && (home = getenv("HOME")) == NULL)
+   {
+      printf("Couldn't figure out users home path (~). Please set the $HOME "
+         "environment variable or specify -d to disable user configuration files.\n");
+      exit(1);
+   }
+
    /* Load user config files or set defaults */
-   home = getenv("HOME");
+   if (flag_ignore_files != 1)
+   {
+   
+      /* Read user configured ranges */
+      path = (char *) malloc (sizeof(char) * (strlen(home) + strlen(RPATH) + 1));
+      sprintf(path, RPATH, home);
 
-   /* Read user configured ranges if arent disabled */
-   path = (char *) malloc (sizeof(char) * (strlen(home) + strlen(RPATH) + 1));
-   sprintf(path, RPATH, home);
+      if ((common_net = fread_list(path)) == NULL)
+         common_net = dcommon_net;
+      free(path);
 
-   if (((common_net = fread_list(path)) == NULL) || (flag_ignore_files == 1))
+      /* Read user configured ips */
+      path = (char *) malloc (sizeof(char) * (strlen(home) + strlen(FPATH) + 1));
+      sprintf(path, FPATH, home);
+
+      if((fast_ips = fread_list(path)) == NULL)
+         fast_ips = dfast_ips;
+      free(path);
+      
+   } else {
+   
+      /* Set defaults */
       common_net = dcommon_net;
-   free(path);
-
-   /* Read user configured ips for fast mode if arent disabled */
-   path = (char *) malloc (sizeof(char) * (strlen(home) + strlen(FPATH) + 1));
-   sprintf(path, FPATH, home);
-
-   if(((fast_ips = fread_list(path)) == NULL) || (flag_ignore_files == 1))
       fast_ips = dfast_ips;
-   free(path);
+      
+   }
 
    /* Read range list given by user if specified */
    if (flag_scan_list == 1) {


### PR DESCRIPTION
I noticed a somewhat hard-to-find bug (or: possible wrong use) in netdiscover when it is run in an environment where the `$HOME` environment variable is not set, as it'll segfault because `strlen(NULL)` is called.
This may e.g. be the case when netdiscover is run from within a systemd-started service, as no default environment is set.

In order to workaround this issue, I've added a check and an error message.
Additionally, in order to prevent the illegal call to `strlen`, I've changed the program flow to only read the configuration files if they're enabled, which shouldn't hurt anyway.

Feel free to reject this PR if you don't like the suggested fix. It'd be also possible to just set `path` to `.` if HOME doesn't exist and modify the manual accordingly, but I thought the fail-fast-approach matches the programs usage.