### PR TITLE
Use unsigned int for data_counter.hosts

### DIFF
--- a/src/data_al.h
+++ b/src/data_al.h
@@ -77,7 +77,7 @@ struct data_al {
    void (*print_line)(void);                                // Print reg line
    void (*print_header)(int width);                         // Print scr header
    void (*add_registry)(struct data_registry *registry);    // Add new registry
-   int  (*hosts_count)(void);                               // Get hosts count
+   unsigned int (*hosts_count)(void);                       // Get hosts count
    void (*print_simple_header)();                           // Print smp header
 };
 

--- a/src/data_reply.c
+++ b/src/data_reply.c
@@ -64,7 +64,7 @@ void reply_next_registry(void) { current_reply = current_reply->next; }
 struct data_registry *reply_current_reply(void) { return current_reply; }
 
 /* Return hosts count */
-int reply_hosts_count(void) { return reply_count.hosts; }
+unsigned int reply_hosts_count(void) { return reply_count.hosts; }
 
 
 

--- a/src/data_request.c
+++ b/src/data_request.c
@@ -64,7 +64,7 @@ void request_next_registry(void) { request_current = request_current->next; }
 struct data_registry *request_current_registry(void) {return request_current;}
 
 /* Return hosts count */
-int request_hosts_count(void) { return request_count.hosts; }
+unsigned int request_hosts_count(void) { return request_count.hosts; }
 
 
 /* Print current registry line (for interactive mode) */

--- a/src/data_unique.c
+++ b/src/data_unique.c
@@ -65,7 +65,7 @@ void unique_next_registry(void) { current_unique = current_unique->next; }
 struct data_registry *unique_current_unique(void) { return current_unique; }
 
 /* Return hosts count */
-int unique_hosts_count(void) { return unique_count.hosts; }
+unsigned int unique_hosts_count(void) { return unique_count.hosts; }
 
 
 /* Print current registry line (for interactive mode) */


### PR DESCRIPTION
The `hosts` member of the `data_counter` structure is an `unsigned int`, which makes sense as the counter is always positive (or zero).

https://github.com/netdiscover-scanner/netdiscover/blob/3402efeb30cc123a9828f51f851276b4041e0694/src/data_al.h#L41-L46

However, `data_request`, `data_reply` and `data_unique` stored the count as `int`.

This is unlikely to cause an issue in practice, but fixing this means one less thing for lint tools to complain about.
