### PR TITLE
Use mtime of oui.txt

### DIFF
--- a/update-oui-database.sh
+++ b/update-oui-database.sh
@@ -59,8 +59,8 @@ VERSION=0.5
 #####################
 
 DATE=$(date +%F | tr -d "-")
-DATE2=$(date +%F)
 NAME=oui.txt-$DATE
+DATE2=$(date -r $NAME +%F)
 OUIFILE=src/oui.h
 
 # Minimum amount of MAC addresses for check. Is not needed to update this every


### PR DESCRIPTION
Use mtime of `oui.txt`
for more reproducible builds with --no-download

This PR was done while working on [reproducible builds for openSUSE](https://en.opensuse.org/openSUSE:Reproducible_Builds).